### PR TITLE
Use pointers to private and shared keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.4
+dotnet: 3.1.4
 os:
 - linux
 - osx

--- a/Noise.Examples/Noise.Examples.csproj
+++ b/Noise.Examples/Noise.Examples.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Noise.Examples/Noise.Examples.csproj
+++ b/Noise.Examples/Noise.Examples.csproj
@@ -7,6 +7,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/Noise.Examples/Program.cs
+++ b/Noise.Examples/Program.cs
@@ -45,85 +45,80 @@ namespace Noise.Examples
                     }
 
                     // Initialize and run the client.
-                    var xck = new Span<byte>(clientStatic.PrivateKey, KeyPair.DhLen).ToArray();
-                    var client = Task.Run((Func<Task?>) (() => Client(xck, serverStatic.PublicKey, Singleton(psk))));
+                    var clientState = protocol.Create(true, s: clientStatic.PrivateKey, sLen: KeyPair.DhLen, rs: serverStatic.PublicKey, psks: Singleton(psk));
+                    var client = Task.Run((Func<Task?>) (() => Client(clientState)));
 
                     // Initialize and run the server.
-					var xsk = new Span<byte>(serverStatic.PrivateKey, KeyPair.DhLen).ToArray();
-                    var server = Task.Run((Func<Task?>) (() => Server(xsk, Singleton(psk))));
+					
+                    var serverState = protocol.Create(false, s: serverStatic.PrivateKey, sLen: KeyPair.DhLen, psks: Singleton(psk));
+                    _ = Task.Run((Func<Task?>) (() => Server(serverState)));
 
                     client.GetAwaiter().GetResult();
                 }
             }
 		}
 
-		private static async Task Client(byte[] s, byte[] rs, IEnumerable<byte[]> psks)
+		private static async Task Client(HandshakeState state)
 		{
 			var buffer = new byte[Protocol.MaxMessageLength];
 
-			using (var handshakeState = protocol.Create(true, s: s, rs: rs, psks: psks))
-			{
-				// Send the first handshake message to the server.
-				var (bytesWritten, _, _) = handshakeState.WriteMessage(null, buffer);
-				await clientToServer.Send(Slice(buffer, bytesWritten));
+            // Send the first handshake message to the server.
+            var (bytesWritten, _, _) = state.WriteMessage(null, buffer);
+            await clientToServer.Send(Slice(buffer, bytesWritten));
 
-				// Receive the second handshake message from the server.
-				var received = await serverToClient.Receive();
-				var (_, _, transport) = handshakeState.ReadMessage(received, buffer);
+            // Receive the second handshake message from the server.
+            var received = await serverToClient.Receive();
+            var (_, _, transport) = state.ReadMessage(received, buffer);
 
-				// Handshake complete, switch to transport mode.
-				using (transport)
-				{
-					foreach (var message in messages)
-					{
-						Memory<byte> request = Encoding.UTF8.GetBytes(message);
+            // Handshake complete, switch to transport mode.
+            using (transport)
+            {
+                foreach (var message in messages)
+                {
+                    Memory<byte> request = Encoding.UTF8.GetBytes(message);
 
-						// Send the message to the server.
-						bytesWritten = transport.WriteMessage(request.Span, buffer);
-						await clientToServer.Send(Slice(buffer, bytesWritten));
+                    // Send the message to the server.
+                    bytesWritten = transport.WriteMessage(request.Span, buffer);
+                    await clientToServer.Send(Slice(buffer, bytesWritten));
 
-						// Receive the response and print it to the standard output.
-						var response = await serverToClient.Receive();
-						var bytesRead = transport.ReadMessage(response, buffer);
+                    // Receive the response and print it to the standard output.
+                    var response = await serverToClient.Receive();
+                    var bytesRead = transport.ReadMessage(response, buffer);
 
-						Console.WriteLine(Encoding.UTF8.GetString(Slice(buffer, bytesRead)));
-					}
-				}
-			}
+                    Console.WriteLine(Encoding.UTF8.GetString(Slice(buffer, bytesRead)));
+                }
+            }
 		}
+        
+        private static async Task Server(HandshakeState handshakeState)
+        {
+            var buffer = new byte[Protocol.MaxMessageLength];
 
-		private static async Task Server(byte[] s, IEnumerable<byte[]> psks)
-		{
-			var buffer = new byte[Protocol.MaxMessageLength];
+            // Receive the first handshake message from the client.
+            var received = await clientToServer.Receive();
+            handshakeState.ReadMessage(received, buffer);
 
-			using (var handshakeState = protocol.Create(false, s: s, psks: psks))
-			{
-				// Receive the first handshake message from the client.
-				var received = await clientToServer.Receive();
-				handshakeState.ReadMessage(received, buffer);
+            // Send the second handshake message to the client.
+            var (bytesWritten, _, transport) = handshakeState.WriteMessage(null, buffer);
+            await serverToClient.Send(Slice(buffer, bytesWritten));
 
-				// Send the second handshake message to the client.
-				var (bytesWritten, _, transport) = handshakeState.WriteMessage(null, buffer);
-				await serverToClient.Send(Slice(buffer, bytesWritten));
+            // Handshake complete, switch to transport mode.
+            using (transport)
+            {
+                for (;;)
+                {
+                    // Receive the message from the client.
+                    var request = await clientToServer.Receive();
+                    var bytesRead = transport.ReadMessage(request, buffer);
 
-				// Handshake complete, switch to transport mode.
-				using (transport)
-				{
-					for (; ; )
-					{
-						// Receive the message from the client.
-						var request = await clientToServer.Receive();
-						var bytesRead = transport.ReadMessage(request, buffer);
+                    // Echo the message back to the client.
+                    bytesWritten = transport.WriteMessage(Slice(buffer, bytesRead), buffer);
+                    await serverToClient.Send(Slice(buffer, bytesWritten));
+                }
+            }
+        }
 
-						// Echo the message back to the client.
-						bytesWritten = transport.WriteMessage(Slice(buffer, bytesRead), buffer);
-						await serverToClient.Send(Slice(buffer, bytesWritten));
-					}
-				}
-			}
-		}
-
-		private static IEnumerable<T> Singleton<T>(T item)
+        private static IEnumerable<T> Singleton<T>(T item)
 		{
 			yield return item;
 		}

--- a/Noise.Examples/Program.cs
+++ b/Noise.Examples/Program.cs
@@ -133,7 +133,7 @@ namespace Noise.Examples
 			return array.AsSpan(0, length).ToArray();
 		}
 
-		// Chanel simulates the network between the client and the server.
+		// Channel simulates the network between the client and the server.
 		private class Channel
 		{
 			private readonly BufferBlock<byte[]> buffer = new BufferBlock<byte[]>();

--- a/Noise.Examples/Program.cs
+++ b/Noise.Examples/Program.cs
@@ -38,14 +38,13 @@ namespace Noise.Examples
                     var psk1 =  PskRef.Create();
                     var psk2 =  PskRef.Create(psk1.ptr);
 
+                    // Initialize and run the server.
+                    var serverState = protocol.Create(false, s: serverStatic.PrivateKey, sLen: KeyPair.DhLen, psks: Singleton(psk2));
+                    _ = Task.Run(() => Server(serverState));
+
                     // Initialize and run the client.
                     var clientState = protocol.Create(true, s: clientStatic.PrivateKey, sLen: KeyPair.DhLen, rs: serverStatic.PublicKey, psks: Singleton(psk1));
-                    var client = Task.Run((Func<Task?>) (() => Client(clientState)));
-
-                    // Initialize and run the server.
-					
-                    var serverState = protocol.Create(false, s: serverStatic.PrivateKey, sLen: KeyPair.DhLen, psks: Singleton(psk2));
-                    _ = Task.Run((Func<Task?>) (() => Server(serverState)));
+                    var client = Task.Run(() => Client(clientState));
 
                     client.GetAwaiter().GetResult();
                 }

--- a/Noise.Examples/Program.cs
+++ b/Noise.Examples/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -36,21 +35,16 @@ namespace Noise.Examples
 			{
                 unsafe
                 {
-                    var psk = new byte[32];
-
-                    // Generate a random 32-byte pre-shared secret key.
-                    using (var random = RandomNumberGenerator.Create())
-                    {
-                        random.GetBytes(psk);
-                    }
+                    var psk1 =  PskRef.Create();
+                    var psk2 =  PskRef.Create(psk1.ptr);
 
                     // Initialize and run the client.
-                    var clientState = protocol.Create(true, s: clientStatic.PrivateKey, sLen: KeyPair.DhLen, rs: serverStatic.PublicKey, psks: Singleton(psk));
+                    var clientState = protocol.Create(true, s: clientStatic.PrivateKey, sLen: KeyPair.DhLen, rs: serverStatic.PublicKey, psks: Singleton(psk1));
                     var client = Task.Run((Func<Task?>) (() => Client(clientState)));
 
                     // Initialize and run the server.
 					
-                    var serverState = protocol.Create(false, s: serverStatic.PrivateKey, sLen: KeyPair.DhLen, psks: Singleton(psk));
+                    var serverState = protocol.Create(false, s: serverStatic.PrivateKey, sLen: KeyPair.DhLen, psks: Singleton(psk2));
                     _ = Task.Run((Func<Task?>) (() => Server(serverState)));
 
                     client.GetAwaiter().GetResult();

--- a/Noise.Tests/BlakeTest.cs
+++ b/Noise.Tests/BlakeTest.cs
@@ -36,7 +36,7 @@ namespace Noise.Tests
 			}
 		}
 
-		[Fact(/*Skip = "Takes too long to complete."*/)]
+		[Fact(Skip = "Takes too long to complete.")]
 		public void TestLargeInput()
 		{
 			var factor = 1031;
@@ -61,7 +61,7 @@ namespace Noise.Tests
 			}
 		}
 
-		[Fact(/*Skip = "Takes too long to complete."*/)]
+		[Fact(Skip = "Takes too long to complete.")]
 		public void TestSplits()
 		{
 			var data = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray().AsSpan();

--- a/Noise.Tests/BlakeTest.cs
+++ b/Noise.Tests/BlakeTest.cs
@@ -36,7 +36,7 @@ namespace Noise.Tests
 			}
 		}
 
-		[Fact(Skip = "Takes too long to complete.")]
+		[Fact(/*Skip = "Takes too long to complete."*/)]
 		public void TestLargeInput()
 		{
 			var factor = 1031;
@@ -61,7 +61,7 @@ namespace Noise.Tests
 			}
 		}
 
-		[Fact(Skip = "Takes too long to complete.")]
+		[Fact(/*Skip = "Takes too long to complete."*/)]
 		public void TestSplits()
 		{
 			var data = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray().AsSpan();

--- a/Noise.Tests/FixedKeyDh.cs
+++ b/Noise.Tests/FixedKeyDh.cs
@@ -5,31 +5,33 @@ namespace Noise.Tests
 	internal class FixedKeyDh : Dh
 	{
 		private static readonly Curve25519 dh = new Curve25519();
-		private readonly byte[] privateKey;
-
-		public FixedKeyDh()
-		{
-		}
+		private readonly byte[] fixedPrivateKey;
 
 		public FixedKeyDh(byte[] privateKey)
 		{
-			this.privateKey = privateKey;
+			fixedPrivateKey = privateKey;
 		}
 
 		public int DhLen => dh.DhLen;
 
 		public KeyPair GenerateKeyPair()
 		{
-			var publicKey = new byte[DhLen];
-			Libsodium.crypto_scalarmult_curve25519_base(publicKey, privateKey);
+            unsafe
+            {
+                var sk = (byte*) Libsodium.sodium_malloc((ulong) DhLen);
+                for (var i = 0; i < DhLen; i++)
+                    sk[i] = fixedPrivateKey[i];
 
-			return new KeyPair(privateKey, publicKey);
+                return GenerateKeyPair(sk);
+            }
 		}
 
-		public KeyPair GenerateKeyPair(ReadOnlySpan<byte> privateKey)
-		{
-			return dh.GenerateKeyPair(privateKey);
-		}
+        public unsafe KeyPair GenerateKeyPair(byte* privateKey)
+        {
+            var publicKey = new byte[DhLen];
+            Libsodium.crypto_scalarmult_curve25519_base(publicKey, privateKey);
+            return new KeyPair(privateKey, DhLen, publicKey);
+        }
 
 		public void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, Span<byte> sharedKey)
 		{

--- a/Noise.Tests/FixedKeyDh.cs
+++ b/Noise.Tests/FixedKeyDh.cs
@@ -33,9 +33,9 @@ namespace Noise.Tests
             return new KeyPair(privateKey, DhLen, publicKey);
         }
 
-		public void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, Span<byte> sharedKey)
+		public unsafe void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, byte* sharedKey, int sharedKeyLen)
 		{
-			dh.Dh(keyPair, publicKey, sharedKey);
+			dh.Dh(keyPair, publicKey, sharedKey, sharedKeyLen);
 		}
 	}
 }

--- a/Noise.Tests/Noise.Tests.csproj
+++ b/Noise.Tests/Noise.Tests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <None Update="Vectors/blake2-kat.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="Vectors/cacophony.txt" CopyToOutputDirectory="PreserveNewest" />

--- a/Noise.Tests/Noise.Tests.csproj
+++ b/Noise.Tests/Noise.Tests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Noise.Tests/NoiseTest.cs
+++ b/Noise.Tests/NoiseTest.cs
@@ -240,8 +240,8 @@ namespace Noise.Tests
 				init.Dispose();
 				resp.Dispose();
 
-				initTransport.Dispose();
-				respTransport.Dispose();
+				initTransport?.Dispose();
+				respTransport?.Dispose();
 			}
 		}
 

--- a/Noise.Tests/NoiseTest.cs
+++ b/Noise.Tests/NoiseTest.cs
@@ -45,7 +45,7 @@ namespace Noise.Tests
 
 				var protocol = Protocol.Parse(protocolName.AsSpan());
 
-                HandshakeState init;
+				HandshakeState init;
                 HandshakeState resp;
                 unsafe
                 {
@@ -255,10 +255,19 @@ namespace Noise.Tests
 			return Hex.Decode(GetString(token, property));
 		}
 		
-		private static List<byte[]> GetPsks(JToken token, string property)
+		private static List<PskRef> GetPsks(JToken token, string property)
 		{
-			return token[property]?.Select(psk => Hex.Decode((string)psk)).ToList();
-		}
+			var tokens = token[property]?.Select(psk => Hex.Decode((string)psk)).ToList();
+			if(tokens == default)
+				return new List<PskRef>(0);
+
+            var list = new List<PskRef>(tokens.Count);
+            foreach (var buffer in tokens)
+            {
+				list.Add(PskRef.Create(buffer));
+            }
+            return list;
+        }
 
 		private static void Swap<T>(ref T x, ref T y)
 		{

--- a/Noise/Aes256Gcm.cs
+++ b/Noise/Aes256Gcm.cs
@@ -23,9 +23,9 @@ namespace Noise
 			}
 		}
 
-		public int Encrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext)
+		public unsafe int Encrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext)
 		{
-			Debug.Assert(k.Length == Aead.KeySize);
+			Debug.Assert(kLen == Aead.KeySize);
 			Debug.Assert(ciphertext.Length >= plaintext.Length + Aead.TagSize);
 
 			Span<byte> nonce = stackalloc byte[Aead.NonceSize];
@@ -40,7 +40,7 @@ namespace Noise
 				ad.Length,
 				IntPtr.Zero,
 				ref MemoryMarshal.GetReference(nonce),
-				ref MemoryMarshal.GetReference(k)
+				k
 			);
 
 			if (result != 0)
@@ -52,9 +52,9 @@ namespace Noise
 			return (int)length;
 		}
 
-		public int Decrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
+		public unsafe int Decrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
 		{
-			Debug.Assert(k.Length == Aead.KeySize);
+			Debug.Assert(kLen == Aead.KeySize);
 			Debug.Assert(ciphertext.Length >= Aead.TagSize);
 			Debug.Assert(plaintext.Length >= ciphertext.Length - Aead.TagSize);
 
@@ -70,7 +70,7 @@ namespace Noise
 				ref MemoryMarshal.GetReference(ad),
 				ad.Length,
 				ref MemoryMarshal.GetReference(nonce),
-				ref MemoryMarshal.GetReference(k)
+				k
 			);
 
 			if (result != 0)

--- a/Noise/Blake2b.cs
+++ b/Noise/Blake2b.cs
@@ -44,7 +44,19 @@ namespace Noise
 			}
 		}
 
-		public void GetHashAndReset(Span<byte> hash)
+        public unsafe void AppendData(byte* data, int dataLen)
+        {
+            if (dataLen > 0)
+            {
+                Libsodium.crypto_generichash_blake2b_update(
+                    aligned,
+                    data,
+                    (ulong)dataLen
+                );
+            }
+        }
+
+        public void GetHashAndReset(Span<byte> hash)
 		{
 			Debug.Assert(hash.Length == HashLen);
 
@@ -57,7 +69,20 @@ namespace Noise
 			Reset();
 		}
 
-		private void Reset()
+        public unsafe void GetHashAndReset(byte* hash, int hashLen)
+        {
+            Debug.Assert(hashLen == HashLen);
+
+            Libsodium.crypto_generichash_blake2b_final(
+                aligned,
+                hash,
+                (UIntPtr)hashLen
+            );
+
+            Reset();
+        }
+
+        private void Reset()
 		{
 			Libsodium.crypto_generichash_blake2b_init(aligned, null, UIntPtr.Zero, (UIntPtr)HashLen);
 		}

--- a/Noise/ChaCha20Poly1305.cs
+++ b/Noise/ChaCha20Poly1305.cs
@@ -13,9 +13,9 @@ namespace Noise
 	/// </summary>
 	internal sealed class ChaCha20Poly1305 : Cipher
 	{
-		public int Encrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext)
+		public unsafe int Encrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext)
 		{
-			Debug.Assert(k.Length == Aead.KeySize);
+			Debug.Assert(kLen == Aead.KeySize);
 			Debug.Assert(ciphertext.Length >= plaintext.Length + Aead.TagSize);
 
 			Span<byte> nonce = stackalloc byte[Aead.NonceSize];
@@ -30,7 +30,7 @@ namespace Noise
 				ad.Length,
 				IntPtr.Zero,
 				ref MemoryMarshal.GetReference(nonce),
-				ref MemoryMarshal.GetReference(k)
+				k
 			);
 
 			if (result != 0)
@@ -42,9 +42,9 @@ namespace Noise
 			return (int)length;
 		}
 
-		public int Decrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
+		public unsafe int Decrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext)
 		{
-			Debug.Assert(k.Length == Aead.KeySize);
+			Debug.Assert(kLen == Aead.KeySize);
 			Debug.Assert(ciphertext.Length >= Aead.TagSize);
 			Debug.Assert(plaintext.Length >= ciphertext.Length - Aead.TagSize);
 
@@ -60,7 +60,7 @@ namespace Noise
 				ref MemoryMarshal.GetReference(ad),
 				ad.Length,
 				ref MemoryMarshal.GetReference(nonce),
-				ref MemoryMarshal.GetReference(k)
+				k
 			);
 
 			if (result != 0)

--- a/Noise/Cipher.cs
+++ b/Noise/Cipher.cs
@@ -16,7 +16,7 @@ namespace Noise
 		/// associated data ad and results in a ciphertext that is the
 		/// same size as the plaintext plus 16 bytes for authentication data.
 		/// </summary>
-		int Encrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext);
+        unsafe int Encrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext);
 
 		/// <summary>
 		/// Decrypts ciphertext using a cipher key k of 32 bytes,
@@ -25,6 +25,6 @@ namespace Noise
 		/// number of bytes read, unless authentication fails, in which
 		/// case an error is signaled to the caller.
 		/// </summary>
-		int Decrypt(ReadOnlySpan<byte> k, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext);
+        unsafe int Decrypt(byte* k, int kLen, ulong n, ReadOnlySpan<byte> ad, ReadOnlySpan<byte> ciphertext, Span<byte> plaintext);
 	}
 }

--- a/Noise/CipherState.cs
+++ b/Noise/CipherState.cs
@@ -77,8 +77,7 @@ namespace Noise
                     return plaintext.Length;
                 }
 				
-				var kx = new Span<byte>(k, Aead.KeySize);
-                return cipher.Encrypt(kx, n++, ad, plaintext, ciphertext);
+				return cipher.Encrypt(k, Aead.KeySize, n++, ad, plaintext, ciphertext);
             }
         }
 
@@ -103,8 +102,7 @@ namespace Noise
                     return ciphertext.Length;
                 }
 
-                var kx = new Span<byte>(k, Aead.KeySize);
-                int bytesRead = cipher.Decrypt(kx, n, ad, ciphertext, plaintext);
+                int bytesRead = cipher.Decrypt(k, Aead.KeySize, n, ad, ciphertext, plaintext);
                 ++n;
 
                 return bytesRead;
@@ -121,8 +119,7 @@ namespace Noise
             unsafe
             {
                 Span<byte> key = stackalloc byte[Aead.KeySize + Aead.TagSize];
-                var kx = new Span<byte>(k, Aead.KeySize);
-                cipher.Encrypt(kx, MaxNonce, zeroLen, zeros, key);
+                cipher.Encrypt(k, Aead.KeySize, MaxNonce, zeroLen, zeros, key);
 
                 EnsureInitialized();
                 var s = key.Slice(Aead.KeySize);

--- a/Noise/Curve25519.cs
+++ b/Noise/Curve25519.cs
@@ -56,21 +56,18 @@ namespace Noise
         }
 
         
-		public void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, Span<byte> sharedKey)
+		public unsafe void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, byte* sharedKey, int sharedKeyLen)
 		{
             Debug.Assert(publicKey.Length == DhLen);
-            Debug.Assert(sharedKey.Length == DhLen);
+            Debug.Assert(sharedKeyLen == DhLen);
 
-            unsafe
-            {
-                Debug.Assert(keyPair.PrivateKey != null);
+            Debug.Assert(keyPair.PrivateKey != null);
 
-                Libsodium.crypto_scalarmult_curve25519(
-                    ref MemoryMarshal.GetReference(sharedKey),
-                    keyPair.PrivateKey,
-                    ref MemoryMarshal.GetReference(publicKey)
-                );
-            }
+            Libsodium.crypto_scalarmult_curve25519(
+                sharedKey,
+                keyPair.PrivateKey,
+                ref MemoryMarshal.GetReference(publicKey)
+            );
         }
 	}
 }

--- a/Noise/Dh.cs
+++ b/Noise/Dh.cs
@@ -28,6 +28,6 @@ namespace Noise
 		/// key in keyPair and the publicKey and writes an output
 		/// sequence of bytes of length DhLen into sharedKey parameter.
 		/// </summary>
-		void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, Span<byte> sharedKey);
+        unsafe void Dh(KeyPair keyPair, ReadOnlySpan<byte> publicKey, byte* sharedKey, int sharedKeyLen);
 	}
 }

--- a/Noise/Dh.cs
+++ b/Noise/Dh.cs
@@ -21,7 +21,7 @@ namespace Noise
 		/// <summary>
 		/// Generates a Diffie-Hellman key pair from the specified private key.
 		/// </summary>
-		KeyPair GenerateKeyPair(ReadOnlySpan<byte> privateKey);
+        unsafe KeyPair GenerateKeyPair(byte* privateKey);
 
 		/// <summary>
 		/// Performs a Diffie-Hellman calculation between the private

--- a/Noise/Exceptions.cs
+++ b/Noise/Exceptions.cs
@@ -12,6 +12,14 @@ namespace Noise
 			}
 		}
 
+        public static unsafe void ThrowIfNull(byte* value, string name)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(name);
+            }
+        }
+
 		public static void ThrowIfDisposed(bool disposed, string name)
 		{
 			if (disposed)

--- a/Noise/HandshakeState.cs
+++ b/Noise/HandshakeState.cs
@@ -434,8 +434,14 @@ namespace Noise
 
 			if (isPsk)
 			{
-				state.MixKey(e.PublicKey);
-			}
+                unsafe
+                {
+                    fixed (byte* ikm = e.PublicKey)
+                    {
+                        state.MixKey(ikm, e.PublicKey.Length);    
+                    }
+                }
+            }
 
 			return buffer.Slice(e.PublicKey.Length);
 		}
@@ -521,8 +527,14 @@ namespace Noise
 
 			if (isPsk)
 			{
-				state.MixKey(re);
-			}
+                unsafe
+                {
+                    fixed (byte* ikm = re)
+                    {
+                        state.MixKey(ikm, dh.DhLen);
+                    }
+                }
+            }
 
 			return buffer.Slice(re.Length);
 		}
@@ -598,9 +610,9 @@ namespace Noise
 
             unsafe
             {
-                byte* sharedKey = stackalloc byte[dh.DhLen];
+                var sharedKey = stackalloc byte[dh.DhLen];
                 dh.Dh(keyPair, publicKey, sharedKey, dh.DhLen);
-                state.MixKey(new ReadOnlySpan<byte>(sharedKey, dh.DhLen));
+                state.MixKey(sharedKey, dh.DhLen);
             }
         }
 

--- a/Noise/HandshakeState.cs
+++ b/Noise/HandshakeState.cs
@@ -186,7 +186,15 @@ namespace Noise
 			this.role = initiator ? Role.Alice : Role.Bob;
 			this.initiator = Role.Alice;
 			this.turnToWrite = initiator;
-			this.s = s.IsEmpty ? null : dh.GenerateKeyPair(s);
+
+            unsafe
+            {
+                fixed (byte* xs = s)
+                {
+                    this.s = s.IsEmpty ? null : dh.GenerateKeyPair(xs);
+                }
+            }
+			
 			this.rs = rs.IsEmpty ? null : rs.ToArray();
 
 			ProcessPreMessages(protocol.HandshakePattern);
@@ -317,7 +325,14 @@ namespace Noise
 			initiator = Role.Bob;
 			turnToWrite = role == Role.Bob;
 
-			s = dh.GenerateKeyPair(config.LocalStatic);
+            unsafe
+            {
+                fixed (byte* xs = config.LocalStatic)
+                {
+                    s = dh.GenerateKeyPair(xs);    
+                }
+            }
+            
 			rs = null;
 
 			isPsk = false;

--- a/Noise/HandshakeState.cs
+++ b/Noise/HandshakeState.cs
@@ -265,7 +265,7 @@ namespace Noise
 
 			var psk = enumerator.Current;
 
-			if (psk.len != Aead.KeySize)
+			if (psk?.len != Aead.KeySize)
 			{
 				throw new ArgumentException($"Pre-shared keys must be {Aead.KeySize} bytes in length.");
 			}

--- a/Noise/HandshakeState.cs
+++ b/Noise/HandshakeState.cs
@@ -596,10 +596,13 @@ namespace Noise
 			Debug.Assert(keyPair != null);
 			Debug.Assert(!publicKey.IsEmpty);
 
-			Span<byte> sharedKey = stackalloc byte[dh.DhLen];
-			dh.Dh(keyPair, publicKey, sharedKey);
-			state.MixKey(sharedKey);
-		}
+            unsafe
+            {
+                byte* sharedKey = stackalloc byte[dh.DhLen];
+                dh.Dh(keyPair, publicKey, sharedKey, dh.DhLen);
+                state.MixKey(new ReadOnlySpan<byte>(sharedKey, dh.DhLen));
+            }
+        }
 
 		private void Clear()
 		{

--- a/Noise/Hash.cs
+++ b/Noise/Hash.cs
@@ -24,9 +24,20 @@ namespace Noise
 		void AppendData(ReadOnlySpan<byte> data);
 
 		/// <summary>
+		/// Appends the specified data to the data already processed in the hash.
+		/// </summary>
+        unsafe void AppendData(byte* data, int dataLen);
+
+        /// <summary>
 		/// Retrieves the hash for the accumulated data into the hash parameter,
 		/// and resets the object to its initial state.
 		/// </summary>
 		void GetHashAndReset(Span<byte> hash);
+
+        /// <summary>
+        /// Retrieves the hash for the accumulated data into the hash parameter,
+        /// and resets the object to its initial state.
+        /// </summary>
+        unsafe void GetHashAndReset(byte* hash, int hashLen);
 	}
 }

--- a/Noise/Hkdf.cs
+++ b/Noise/Hkdf.cs
@@ -17,40 +17,6 @@ namespace Noise
 		private readonly HashType outer = new HashType();
 		private bool disposed;
 
-		/// <summary>
-        /// Takes a chainingKey byte sequence of length HashLen,
-        /// and an inputKeyMaterial byte sequence with length
-        /// either zero bytes, 32 bytes, or DhLen bytes. Writes a
-        /// byte sequences of length 2 * HashLen into output parameter.
-        /// </summary>
-        public unsafe void ExtractAndExpand2(
-            byte* chainingKey,
-            int chainingKeyLen,
-            ReadOnlySpan<byte> inputKeyMaterial,
-            Span<byte> output)
-        {
-            var hashLen = inner.HashLen;
-
-            Debug.Assert(chainingKeyLen == hashLen);
-            Debug.Assert(output.Length == 2 * hashLen);
-
-            var tempKey = stackalloc byte[hashLen];
-
-            HmacHash(chainingKey, chainingKeyLen, tempKey, hashLen, inputKeyMaterial);
-
-            var output1 = output.Slice(0, hashLen);
-            fixed (byte* o1 = &output1.GetPinnableReference())
-            {
-                HmacHash(tempKey, hashLen, o1, hashLen, one);
-            }
-                    
-            var output2 = output.Slice(hashLen, hashLen);
-            fixed(byte* o2 = &output2.GetPinnableReference())
-            {
-                HmacHash(tempKey, hashLen, o2, hashLen, output1, two);    
-            }
-        }
-
         /// <summary>
         /// Takes a chainingKey byte sequence of length HashLen,
         /// and an inputKeyMaterial byte sequence with length

--- a/Noise/Hkdf.cs
+++ b/Noise/Hkdf.cs
@@ -19,41 +19,36 @@ namespace Noise
 		private bool disposed;
 
 		/// <summary>
-		/// Takes a chainingKey byte sequence of length HashLen,
-		/// and an inputKeyMaterial byte sequence with length
-		/// either zero bytes, 32 bytes, or DhLen bytes. Writes a
-		/// byte sequences of length 2 * HashLen into output parameter.
-		/// </summary>
-		public void ExtractAndExpand2(
-			ReadOnlySpan<byte> chainingKey,
-			ReadOnlySpan<byte> inputKeyMaterial,
-			Span<byte> output)
-		{
-			int hashLen = inner.HashLen;
+        /// Takes a chainingKey byte sequence of length HashLen,
+        /// and an inputKeyMaterial byte sequence with length
+        /// either zero bytes, 32 bytes, or DhLen bytes. Writes a
+        /// byte sequences of length 2 * HashLen into output parameter.
+        /// </summary>
+        public unsafe void ExtractAndExpand2(
+            byte* chainingKey,
+            int chainingKeyLen,
+            ReadOnlySpan<byte> inputKeyMaterial,
+            Span<byte> output)
+        {
+            var hashLen = inner.HashLen;
 
-			Debug.Assert(chainingKey.Length == hashLen);
-			Debug.Assert(output.Length == 2 * hashLen);
+            Debug.Assert(chainingKeyLen == hashLen);
+            Debug.Assert(output.Length == 2 * hashLen);
 
-            unsafe
+            var tempKey = stackalloc byte[hashLen];
+
+            HmacHash(chainingKey, chainingKeyLen, tempKey, hashLen, inputKeyMaterial);
+
+            var output1 = output.Slice(0, hashLen);
+            fixed (byte* o1 = &output1.GetPinnableReference())
             {
-                fixed (byte* ck = chainingKey)
-                {
-                    var tempKey = stackalloc byte[hashLen];
-
-                    HmacHash(ck, hashLen, tempKey, hashLen, inputKeyMaterial);
-
-                    var output1 = output.Slice(0, hashLen);
-                    fixed (byte* o1 = &output1.GetPinnableReference())
-                    {
-                        HmacHash(tempKey, hashLen, o1, hashLen, one);
-                    }
+                HmacHash(tempKey, hashLen, o1, hashLen, one);
+            }
                     
-                    var output2 = output.Slice(hashLen, hashLen);
-                    fixed(byte* o2 = &output2.GetPinnableReference())
-                    {
-                        HmacHash(tempKey, hashLen, o2, hashLen, output1, two);    
-                    }
-                }
+            var output2 = output.Slice(hashLen, hashLen);
+            fixed(byte* o2 = &output2.GetPinnableReference())
+            {
+                HmacHash(tempKey, hashLen, o2, hashLen, output1, two);    
             }
         }
 
@@ -68,14 +63,14 @@ namespace Noise
 			ReadOnlySpan<byte> inputKeyMaterial,
 			Span<byte> output)
 		{
-			int hashLen = inner.HashLen;
+			var hashLen = inner.HashLen;
 
 			Debug.Assert(chainingKey.Length == hashLen);
 			Debug.Assert(output.Length == 3 * hashLen);
 
             unsafe
             {
-                byte* tempKey = stackalloc byte[hashLen];
+                var tempKey = stackalloc byte[hashLen];
 
                 fixed (byte* ck = chainingKey)
                 {
@@ -102,7 +97,46 @@ namespace Noise
             }
         }
 
-		private unsafe void HmacHash(
+        /// <summary>
+        /// Takes a chainingKey byte sequence of length HashLen,
+        /// and an inputKeyMaterial byte sequence with length
+        /// either zero bytes, 32 bytes, or DhLen bytes. Writes a
+        /// byte sequences of length 3 * HashLen into output parameter.
+        /// </summary>
+        public unsafe void ExtractAndExpand3(
+            byte* chainingKey,
+            int chainingKeyLen,
+            ReadOnlySpan<byte> inputKeyMaterial,
+            Span<byte> output)
+        {
+            var hashLen = inner.HashLen;
+
+            Debug.Assert(chainingKeyLen == hashLen);
+            Debug.Assert(output.Length == 3 * hashLen);
+
+            var tempKey = stackalloc byte[hashLen];
+
+            HmacHash(chainingKey, chainingKeyLen, tempKey, hashLen, inputKeyMaterial);
+
+            var output1 = output.Slice(0, hashLen);
+            fixed (byte* o1 = &output1.GetPinnableReference())
+            {
+                HmacHash(tempKey, hashLen, o1, hashLen, one);
+            }
+
+            var output2 = output.Slice(hashLen, hashLen);
+            fixed (byte* o2 = &output2.GetPinnableReference())
+            {
+                HmacHash(tempKey, hashLen, o2, hashLen, output1, two);
+            }
+                   
+            var output3 = output.Slice(2 * hashLen, hashLen);
+            fixed (byte* o3 = &output3.GetPinnableReference())
+            {
+                HmacHash(tempKey, hashLen, o3, hashLen, output2, three); 
+            }
+        }
+        private unsafe void HmacHash(
 			byte* key,
 			int keyLen,
 			byte* hmac,
@@ -110,37 +144,34 @@ namespace Noise
 			ReadOnlySpan<byte> data1 = default,
 			ReadOnlySpan<byte> data2 = default)
 		{
-            unsafe
+            Debug.Assert(keyLen == inner.HashLen);
+            Debug.Assert(hmacLen == inner.HashLen);
+
+            var blockLen = inner.BlockLen;
+
+            var ipad = stackalloc byte[blockLen];
+            var opad = stackalloc byte[blockLen];
+
+            for (var i = 0; i < keyLen; i++)
             {
-                Debug.Assert(keyLen == inner.HashLen);
-                Debug.Assert(hmacLen == inner.HashLen);
-
-                var blockLen = inner.BlockLen;
-
-                var ipad = stackalloc byte[blockLen];
-                var opad = stackalloc byte[blockLen];
-
-                for (var i = 0; i < keyLen; i++)
-                {
-                    ipad[i] = key[i];
-                    opad[i] = key[i];
-                }
-
-                for (var i = 0; i < blockLen; ++i)
-                {
-                    ipad[i] ^= 0x36;
-                    opad[i] ^= 0x5C;
-                }
-
-                inner.AppendData(ipad, blockLen);
-                inner.AppendData(data1);
-                inner.AppendData(data2);
-                inner.GetHashAndReset(hmac, hmacLen);
-
-                outer.AppendData(opad, blockLen);
-                outer.AppendData(hmac, hmacLen);
-                outer.GetHashAndReset(hmac, hmacLen);
+                ipad[i] = key[i];
+                opad[i] = key[i];
             }
+
+            for (var i = 0; i < blockLen; ++i)
+            {
+                ipad[i] ^= 0x36;
+                opad[i] ^= 0x5C;
+            }
+
+            inner.AppendData(ipad, blockLen);
+            inner.AppendData(data1);
+            inner.AppendData(data2);
+            inner.GetHashAndReset(hmac, hmacLen);
+
+            outer.AppendData(opad, blockLen);
+            outer.AppendData(hmac, hmacLen);
+            outer.GetHashAndReset(hmac, hmacLen);
         }
 
 		public void Dispose()

--- a/Noise/Hkdf.cs
+++ b/Noise/Hkdf.cs
@@ -51,52 +51,7 @@ namespace Noise
                 HmacHash(tempKey, hashLen, o2, hashLen, output1, two);    
             }
         }
-
-		/// <summary>
-		/// Takes a chainingKey byte sequence of length HashLen,
-		/// and an inputKeyMaterial byte sequence with length
-		/// either zero bytes, 32 bytes, or DhLen bytes. Writes a
-		/// byte sequences of length 3 * HashLen into output parameter.
-		/// </summary>
-		public void ExtractAndExpand3(
-			ReadOnlySpan<byte> chainingKey,
-			ReadOnlySpan<byte> inputKeyMaterial,
-			Span<byte> output)
-		{
-			var hashLen = inner.HashLen;
-
-			Debug.Assert(chainingKey.Length == hashLen);
-			Debug.Assert(output.Length == 3 * hashLen);
-
-            unsafe
-            {
-                var tempKey = stackalloc byte[hashLen];
-
-                fixed (byte* ck = chainingKey)
-                {
-                    HmacHash(ck, chainingKey.Length, tempKey, hashLen, inputKeyMaterial);
-
-                    var output1 = output.Slice(0, hashLen);
-                    fixed (byte* o1 = &output1.GetPinnableReference())
-                    {
-                        HmacHash(tempKey, hashLen, o1, hashLen, one);
-                    }
-
-                    var output2 = output.Slice(hashLen, hashLen);
-                    fixed (byte* o2 = &output2.GetPinnableReference())
-                    {
-                        HmacHash(tempKey, hashLen, o2, hashLen, output1, two);
-                    }
-                   
-                    var output3 = output.Slice(2 * hashLen, hashLen);
-                    fixed (byte* o3 = &output3.GetPinnableReference())
-                    {
-                        HmacHash(tempKey, hashLen, o3, hashLen, output2, three); 
-                    }
-                }
-            }
-        }
-
+        
         /// <summary>
         /// Takes a chainingKey byte sequence of length HashLen,
         /// and an inputKeyMaterial byte sequence with length

--- a/Noise/Hkdf.cs
+++ b/Noise/Hkdf.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace Noise
 {

--- a/Noise/Libsodium.cs
+++ b/Noise/Libsodium.cs
@@ -30,7 +30,7 @@ namespace Noise
 		private static extern int crypto_aead_aes256gcm_is_available();
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_aead_aes256gcm_encrypt(
+		public static extern unsafe int crypto_aead_aes256gcm_encrypt(
 			ref byte c,
 			out long clen_p,
 			ref byte m,
@@ -39,11 +39,11 @@ namespace Noise
 			long adlen,
 			IntPtr nsec,
 			ref byte npub,
-			ref byte k
+			byte* k
 		);
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_aead_aes256gcm_decrypt(
+		public static extern unsafe int crypto_aead_aes256gcm_decrypt(
 			ref byte m,
 			out long mlen_p,
 			IntPtr nsec,
@@ -52,11 +52,11 @@ namespace Noise
 			ref byte ad,
 			long adlen,
 			ref byte npub,
-			ref byte k
+			byte* k
 		);
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_aead_chacha20poly1305_ietf_encrypt(
+		public static extern unsafe int crypto_aead_chacha20poly1305_ietf_encrypt(
 			ref byte c,
 			out long clen_p,
 			ref byte m,
@@ -65,11 +65,11 @@ namespace Noise
 			long adlen,
 			IntPtr nsec,
 			ref byte npub,
-			ref byte k
+			byte* k
 		);
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_aead_chacha20poly1305_ietf_decrypt(
+		public static extern unsafe int crypto_aead_chacha20poly1305_ietf_decrypt(
 			ref byte m,
 			out long mlen_p,
 			IntPtr nsec,
@@ -78,7 +78,7 @@ namespace Noise
 			ref byte ad,
 			long adlen,
 			ref byte npub,
-			ref byte k
+			byte* k
 		);
 
         [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]

--- a/Noise/Libsodium.cs
+++ b/Noise/Libsodium.cs
@@ -81,18 +81,18 @@ namespace Noise
 			ref byte k
 		);
 
-		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_scalarmult_curve25519_base(
-			byte[] q,
-			byte[] n
-		);
-
-		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int crypto_scalarmult_curve25519(
-			ref byte q,
-			ref byte n,
-			ref byte p
-		);
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_scalarmult_curve25519_base(
+            byte[] q,
+            byte* n
+        );
+		
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_scalarmult_curve25519(
+            ref byte q,
+            byte* n,
+            ref byte p
+        );
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_hash_sha256_init(
@@ -160,6 +160,12 @@ namespace Noise
         [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe void sodium_free(
             void* ptr
+        );
+
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void randombytes_buf(
+            byte* buf, 
+            uint size
         );
 	}
 }

--- a/Noise/Libsodium.cs
+++ b/Noise/Libsodium.cs
@@ -151,5 +151,15 @@ namespace Noise
 			ref byte @out,
 			UIntPtr outlen
 		);
+
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void* sodium_malloc(
+            ulong size
+        );
+		
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void sodium_free(
+            void* ptr
+        );
 	}
 }

--- a/Noise/Libsodium.cs
+++ b/Noise/Libsodium.cs
@@ -106,11 +106,24 @@ namespace Noise
 			ulong inlen
 		);
 
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_hash_sha256_update(
+            IntPtr state,
+            byte* @in,
+            ulong inlen
+        );
+
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_hash_sha256_final(
 			IntPtr state,
 			ref byte @out
 		);
+
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_hash_sha256_final(
+            IntPtr state,
+            byte* @out
+        );
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_hash_sha512_init(
@@ -124,11 +137,24 @@ namespace Noise
 			ulong inlen
 		);
 
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_hash_sha512_update(
+            IntPtr state,
+            byte* @in,
+            ulong inlen
+        );
+
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_hash_sha512_final(
 			IntPtr state,
 			ref byte @out
 		);
+
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_hash_sha512_final(
+            IntPtr state,
+            byte* @out
+        );
 
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_generichash_blake2b_init(
@@ -145,12 +171,26 @@ namespace Noise
 			ulong inlen
 		);
 
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_generichash_blake2b_update(
+            IntPtr state,
+            byte* @in,
+            ulong inlen
+        );
+
 		[DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int crypto_generichash_blake2b_final(
 			IntPtr state,
 			ref byte @out,
 			UIntPtr outlen
 		);
+
+        [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int crypto_generichash_blake2b_final(
+            IntPtr state,
+            byte* @out,
+            UIntPtr outlen
+        );
 
         [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe void* sodium_malloc(

--- a/Noise/Libsodium.cs
+++ b/Noise/Libsodium.cs
@@ -89,7 +89,7 @@ namespace Noise
 		
         [DllImport(Name, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe int crypto_scalarmult_curve25519(
-            ref byte q,
+            byte* q,
             byte* n,
             ref byte p
         );

--- a/Noise/Noise.csproj
+++ b/Noise/Noise.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Noise.NET</PackageId>
     <Title>Noise.NET</Title>
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libsodium" Version="1.0.16" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="libsodium" Version="1.0.18" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Noise/Noise.csproj
+++ b/Noise/Noise.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Noise.NET</PackageId>
     <Title>Noise.NET</Title>
@@ -12,7 +13,7 @@
     <RepositoryUrl>https://github.com/Metalnem/noise</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Metalnem/noise/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/Metalnem/noise/master/PackageIcon.png</PackageIconUrl>
-    <Description>.NET Standard 1.3 implementation of the Noise Protocol Framework (revision 33 of the spec)</Description>
+    <Description>.NET Standard 2.0 implementation of the Noise Protocol Framework (revision 33 of the spec)</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright © 2018, Nemanja Mijailovic</Copyright>
     <PackageTags>crypto cryptography security encryption noise noise-protocol noise-protocol-framework</PackageTags>

--- a/Noise/Noise.csproj
+++ b/Noise/Noise.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Noise/Protocol.cs
+++ b/Noise/Protocol.cs
@@ -139,11 +139,11 @@ namespace Noise
 			byte* s = default,
 			int sLen = default,
 			byte[] rs = default,
-			IEnumerable<byte[]> psks = default)
+			IEnumerable<PskRef> psks = default)
 		{
 			if (psks == null)
 			{
-				psks = Enumerable.Empty<byte[]>();
+				psks = Enumerable.Empty<PskRef>();
 			}
 
 			if (Cipher == CipherFunction.AesGcm && Hash == HashFunction.Sha256)

--- a/Noise/Protocol.cs
+++ b/Noise/Protocol.cs
@@ -108,34 +108,36 @@ namespace Noise
 
 		internal byte[] Name { get; }
 
-		/// <summary>
-		/// Creates an initial <see cref="HandshakeState"/>.
-		/// </summary>
-		/// <param name="initiator">A boolean indicating the initiator or responder role.</param>
-		/// <param name="prologue">
-		/// A byte sequence which may be zero-length, or which may contain
-		/// context information that both parties want to confirm is identical.
-		/// </param>
-		/// <param name="s">The local static private key (optional).</param>
-		/// <param name="rs">The remote party's static public key (optional).</param>
-		/// <param name="psks">The collection of zero or more 32-byte pre-shared secret keys.</param>
-		/// <returns>The initial handshake state.</returns>
-		/// <exception cref="ArgumentException">
-		/// Thrown if any of the following conditions is satisfied:
-		/// <para>- <paramref name="s"/> is not a valid DH private key.</para>
-		/// <para>- <paramref name="rs"/> is not a valid DH public key.</para>
-		/// <para>- <see cref="HandshakePattern"/> requires the <see cref="HandshakeState"/>
-		/// to be initialized with local and/or remote static key,
-		/// but <paramref name="s"/> and/or <paramref name="rs"/> is null.</para>
-		/// <para>- One or more pre-shared keys are not 32 bytes in length.</para>
-		/// <para>- Number of pre-shared keys does not match the number of PSK modifiers.</para>
-		/// <para>- Fallback modifier is present (fallback can only be applied by calling
-		/// the <see cref="HandshakeState.Fallback"/> method on existing handshake state).</para>
-		/// </exception>
-		public HandshakeState Create(
+        /// <summary>
+        /// Creates an initial <see cref="HandshakeState"/>.
+        /// </summary>
+        /// <param name="initiator">A boolean indicating the initiator or responder role.</param>
+        /// <param name="prologue">
+        /// A byte sequence which may be zero-length, or which may contain
+        /// context information that both parties want to confirm is identical.
+        /// </param>
+        /// <param name="s">The local static private key (optional).</param>
+        /// <param name="sLen">The local static private key length (optional).</param>
+        /// <param name="rs">The remote party's static public key (optional).</param>
+        /// <param name="psks">The collection of zero or more 32-byte pre-shared secret keys.</param>
+        /// <returns>The initial handshake state.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if any of the following conditions is satisfied:
+        /// <para>- <paramref name="s"/> is not a valid DH private key.</para>
+        /// <para>- <paramref name="rs"/> is not a valid DH public key.</para>
+        /// <para>- <see cref="HandshakePattern"/> requires the <see cref="HandshakeState"/>
+        /// to be initialized with local and/or remote static key,
+        /// but <paramref name="s"/> and/or <paramref name="rs"/> is null.</para>
+        /// <para>- One or more pre-shared keys are not 32 bytes in length.</para>
+        /// <para>- Number of pre-shared keys does not match the number of PSK modifiers.</para>
+        /// <para>- Fallback modifier is present (fallback can only be applied by calling
+        /// the <see cref="HandshakeState.Fallback"/> method on existing handshake state).</para>
+        /// </exception>
+        public unsafe HandshakeState Create(
 			bool initiator,
 			ReadOnlySpan<byte> prologue = default,
-			byte[] s = default,
+			byte* s = default,
+			int sLen = default,
 			byte[] rs = default,
 			IEnumerable<byte[]> psks = default)
 		{
@@ -146,35 +148,35 @@ namespace Noise
 
 			if (Cipher == CipherFunction.AesGcm && Hash == HashFunction.Sha256)
 			{
-				return new HandshakeState<Aes256Gcm, Curve25519, Sha256>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<Aes256Gcm, Curve25519, Sha256>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.AesGcm && Hash == HashFunction.Sha512)
 			{
-				return new HandshakeState<Aes256Gcm, Curve25519, Sha512>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<Aes256Gcm, Curve25519, Sha512>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.AesGcm && Hash == HashFunction.Blake2s)
 			{
-				return new HandshakeState<Aes256Gcm, Curve25519, Blake2s>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<Aes256Gcm, Curve25519, Blake2s>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.AesGcm && Hash == HashFunction.Blake2b)
 			{
-				return new HandshakeState<Aes256Gcm, Curve25519, Blake2b>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<Aes256Gcm, Curve25519, Blake2b>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.ChaChaPoly && Hash == HashFunction.Sha256)
 			{
-				return new HandshakeState<ChaCha20Poly1305, Curve25519, Sha256>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<ChaCha20Poly1305, Curve25519, Sha256>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.ChaChaPoly && Hash == HashFunction.Sha512)
 			{
-				return new HandshakeState<ChaCha20Poly1305, Curve25519, Sha512>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<ChaCha20Poly1305, Curve25519, Sha512>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.ChaChaPoly && Hash == HashFunction.Blake2s)
 			{
-				return new HandshakeState<ChaCha20Poly1305, Curve25519, Blake2s>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<ChaCha20Poly1305, Curve25519, Blake2s>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else if (Cipher == CipherFunction.ChaChaPoly && Hash == HashFunction.Blake2b)
 			{
-				return new HandshakeState<ChaCha20Poly1305, Curve25519, Blake2b>(this, initiator, prologue, s, rs, psks);
+				return new HandshakeState<ChaCha20Poly1305, Curve25519, Blake2b>(this, initiator, prologue, s, sLen, rs, psks);
 			}
 			else
 			{
@@ -208,8 +210,14 @@ namespace Noise
 		{
 			Exceptions.ThrowIfNull(config, nameof(config));
 
-			return Create(config.Initiator, config.Prologue, config.LocalStatic, config.RemoteStatic, config.PreSharedKeys);
-		}
+            unsafe
+            {
+                fixed (byte* xls = config.LocalStatic)
+                {
+                    return Create(config.Initiator, config.Prologue, xls, config.LocalStatic.Length, config.RemoteStatic, config.PreSharedKeys);
+                }    
+            }
+        }
 
 		/// <summary>
 		/// Converts the Noise protocol name to its <see cref="Protocol"/> equivalent.

--- a/Noise/ProtocolConfig.cs
+++ b/Noise/ProtocolConfig.cs
@@ -24,7 +24,7 @@ namespace Noise
 			byte[] prologue = default,
 			byte[] s = default,
 			byte[] rs = default,
-			IEnumerable<byte[]> psks = default)
+			IEnumerable<PskRef> psks = default)
 		{
 			Initiator = initiator;
 			Prologue = prologue;
@@ -58,6 +58,6 @@ namespace Noise
 		/// <summary>
 		/// Gets or sets the collection of zero or more 32-byte pre-shared secret keys.
 		/// </summary>
-		public IEnumerable<byte[]> PreSharedKeys { get; set; }
+		public IEnumerable<PskRef> PreSharedKeys { get; set; }
 	}
 }

--- a/Noise/PskRef.cs
+++ b/Noise/PskRef.cs
@@ -1,18 +1,36 @@
 using System;
+using System.Threading;
 
 namespace Noise
 {
-    public sealed class PskRef : IDisposable
+    /// <summary>
+    /// Holds a reference to a pre-shared key in unmanaged memory.
+    /// </summary>
+    public struct PskRef : IDisposable
     {
+        /// <summary>
+        /// A reference to the pre-shared key in memory. 
+        /// </summary>
         public unsafe byte* ptr;
+
+        /// <summary>
+        /// The length of the pre-shared key.
+        /// </summary>
         public int len;
 
         private unsafe PskRef(byte* ptr, uint size)
         {
             this.ptr = ptr;
             len = (int) size;
+            _disposed = 0;
         }
 
+        /// <summary>
+        /// Creates a new pre-shared key of a given length.
+        /// The key is filled with random, non-zero bytes in a cryptographically secure fashion. 
+        /// </summary>
+        /// <param name="size">Tge size of the key to generate.</param>
+        /// <returns></returns>
         public static PskRef Create(uint size = Aead.KeySize)
         {
             unsafe
@@ -23,17 +41,27 @@ namespace Noise
             }
         }
 
+        /// <summary>
+        /// Creates a new pre-shared key based on an existing pointer.
+        /// This allocates a new copy of the existing key, which protects against disposal of the cloned key.
+        /// </summary>
+        /// <param name="buffer">A reference to the existing key.</param>
+        /// <param name="len">The length of the existing key to copy into the new key.</param>
+        /// <returns></returns>
         public static unsafe PskRef Create(byte* buffer, uint len = Aead.KeySize)
         {
-            unsafe
-            {
-                var b = (byte*) Libsodium.sodium_malloc(len);
-                for (var i = 0; i < len; i++)
-                    b[i] = buffer[i];
-                return new PskRef(b, len);
-            }
+            var b = (byte*) Libsodium.sodium_malloc(len);
+            for (var i = 0; i < len; i++)
+                b[i] = buffer[i];
+            return new PskRef(b, len);
         }
 
+        /// <summary>
+        /// Creates a new pre-shared key reference based on an existing data buffer.
+        /// Mainly useful for tests, as passing an in-memory buffer exposes the key.
+        /// </summary>
+        /// <param name="buffer">The pre-defined buffer representing the key.</param>
+        /// <returns></returns>
         public static PskRef Create(byte[] buffer)
         {
             unsafe
@@ -46,23 +74,18 @@ namespace Noise
             }
         }
 
-        private void ReleaseUnmanagedResources()
+        private int _disposed;
+
+        /// <inheritdoc />
+        public void Dispose()
         {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+                return;
+
             unsafe
             {
                 Libsodium.sodium_free(ptr);
             }
-        }
-
-        public void Dispose()
-        {
-            ReleaseUnmanagedResources();
-            GC.SuppressFinalize(this);
-        }
-
-        ~PskRef()
-        {
-            ReleaseUnmanagedResources();
         }
     }
 }

--- a/Noise/PskRef.cs
+++ b/Noise/PskRef.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Noise
+{
+    public sealed class PskRef : IDisposable
+    {
+        public unsafe byte* ptr;
+        public int len;
+
+        private unsafe PskRef(byte* ptr, uint size)
+        {
+            this.ptr = ptr;
+            len = (int) size;
+        }
+
+        public static PskRef Create(uint size = Aead.KeySize)
+        {
+            unsafe
+            {
+                var ptr = (byte*) Libsodium.sodium_malloc(size);
+                Libsodium.randombytes_buf(ptr, size);
+                return new PskRef(ptr, size);
+            }
+        }
+
+        public static unsafe PskRef Create(byte* buffer, uint len = Aead.KeySize)
+        {
+            unsafe
+            {
+                var b = (byte*) Libsodium.sodium_malloc(len);
+                for (var i = 0; i < len; i++)
+                    b[i] = buffer[i];
+                return new PskRef(b, len);
+            }
+        }
+
+        public static PskRef Create(byte[] buffer)
+        {
+            unsafe
+            {
+                var len = buffer.Length;
+                var b = (byte*) Libsodium.sodium_malloc((ulong) len);
+                for (var i = 0; i < buffer.Length; i++)
+                    b[i] = buffer[i];
+                return new PskRef(b, (uint) len);
+            }
+        }
+
+        private void ReleaseUnmanagedResources()
+        {
+            unsafe
+            {
+                Libsodium.sodium_free(ptr);
+            }
+        }
+
+        public void Dispose()
+        {
+            ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        ~PskRef()
+        {
+            ReleaseUnmanagedResources();
+        }
+    }
+}

--- a/Noise/Sha256.cs
+++ b/Noise/Sha256.cs
@@ -35,7 +35,19 @@ namespace Noise
 			}
 		}
 
-		public void GetHashAndReset(Span<byte> hash)
+        public unsafe void AppendData(byte* data, int dataLen)
+        {
+            if (dataLen > 0)
+            {
+                Libsodium.crypto_hash_sha256_update(
+                    state,
+                    data,
+                    (ulong)dataLen
+                );
+            }
+        }
+
+        public void GetHashAndReset(Span<byte> hash)
 		{
 			Debug.Assert(hash.Length == HashLen);
 
@@ -47,7 +59,19 @@ namespace Noise
 			Reset();
 		}
 
-		private void Reset()
+        public unsafe void GetHashAndReset(byte* hash, int hashLen)
+        {
+            Debug.Assert(hashLen == HashLen);
+
+            Libsodium.crypto_hash_sha256_final(
+                state,
+                hash
+            );
+
+            Reset();
+        }
+
+        private void Reset()
 		{
 			Libsodium.crypto_hash_sha256_init(state);
 		}

--- a/Noise/Sha512.cs
+++ b/Noise/Sha512.cs
@@ -35,7 +35,19 @@ namespace Noise
 			}
 		}
 
-		public void GetHashAndReset(Span<byte> hash)
+        public unsafe void AppendData(byte* data, int dataLen)
+        {
+            if (dataLen > 0)
+            {
+                Libsodium.crypto_hash_sha512_update(
+                    state,
+                    data,
+                    (ulong)dataLen
+                );
+            }
+        }
+
+        public void GetHashAndReset(Span<byte> hash)
 		{
 			Debug.Assert(hash.Length == HashLen);
 
@@ -47,7 +59,19 @@ namespace Noise
 			Reset();
 		}
 
-		private void Reset()
+        public unsafe void GetHashAndReset(byte* hash, int hashLen)
+        {
+            Debug.Assert(hashLen == HashLen);
+
+            Libsodium.crypto_hash_sha512_final(
+                state,
+                hash
+            );
+
+            Reset();
+        }
+
+        private void Reset()
 		{
 			Libsodium.crypto_hash_sha512_init(state);
 		}

--- a/Noise/SymmetricState.cs
+++ b/Noise/SymmetricState.cs
@@ -156,7 +156,7 @@ namespace Noise
             unsafe
             {
                 Span<byte> output = stackalloc byte[2 * hash.HashLen];
-                hkdf.ExtractAndExpand2(ck, hash.HashLen, null, output);
+                hkdf.ExtractAndExpand2(ck, hash.HashLen, default, 0, output);
 
                 var tempK1 = output.Slice(0, Aead.KeySize);
                 var tempK2 = output.Slice(hash.HashLen, Aead.KeySize);

--- a/Noise/SymmetricState.cs
+++ b/Noise/SymmetricState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Noise
 {
@@ -19,7 +20,7 @@ namespace Noise
 		private readonly CipherState<CipherType> state = new CipherState<CipherType>();
 		private readonly unsafe byte* ck;
 		private readonly byte[] h;
-		private bool disposed;
+		private int disposed;
 
         /// <summary>
         /// Initializes a new SymmetricState with an
@@ -179,17 +180,16 @@ namespace Noise
 
 		public void Dispose()
 		{
-			if (!disposed)
-			{
-				hash.Dispose();
-				hkdf.Dispose();
-				state.Dispose();
-                unsafe
-                {
-					Libsodium.sodium_free(ck);
-                }
-                disposed = true;
-			}
-		}
+            if (Interlocked.CompareExchange(ref disposed, 1, 0) != 0)
+                return;
+
+            hash.Dispose();
+            hkdf.Dispose();
+            state.Dispose();
+            unsafe
+            {
+                Libsodium.sodium_free(ck);
+            }
+        }
 	}
 }

--- a/Noise/SymmetricState.cs
+++ b/Noise/SymmetricState.cs
@@ -68,8 +68,7 @@ namespace Noise
 
                 Span<byte> output = stackalloc byte[2 * hash.HashLen];
 
-                var ckx = new Span<byte>(ck, hash.HashLen);
-                hkdf.ExtractAndExpand2(ckx, inputKeyMaterial, output);
+                hkdf.ExtractAndExpand2(ck, hash.HashLen, inputKeyMaterial, output);
 
                 var slice = output.Slice(0, hash.HashLen);
                 for (var i = 0; i < hash.HashLen; i++)
@@ -100,15 +99,13 @@ namespace Noise
 		{
             unsafe
             {
-                int length = inputKeyMaterial.len;
+                var length = inputKeyMaterial.len;
                 Debug.Assert(length == 0 || length == Aead.KeySize || length == dh.DhLen);
 
                 Span<byte> output = stackalloc byte[3 * hash.HashLen];
                 
-				var ckx = new Span<byte>(ck, hash.HashLen);
-
-                var ikx = new Span<byte>(inputKeyMaterial.ptr, length);
-                hkdf.ExtractAndExpand3(ckx, ikx, output);
+				var ikx = new Span<byte>(inputKeyMaterial.ptr, length);
+                hkdf.ExtractAndExpand3(ck, hash.HashLen, ikx, output);
 
                 var slice = output.Slice(0, hash.HashLen);
                 for (var i = 0; i < hash.HashLen; i++)
@@ -163,8 +160,7 @@ namespace Noise
             unsafe
             {
                 Span<byte> output = stackalloc byte[2 * hash.HashLen];
-                var ckx = new Span<byte>(ck, hash.HashLen);
-                hkdf.ExtractAndExpand2(ckx, null, output);
+                hkdf.ExtractAndExpand2(ck, hash.HashLen, null, output);
 
                 var tempK1 = output.Slice(0, Aead.KeySize);
                 var tempK2 = output.Slice(hash.HashLen, Aead.KeySize);

--- a/Noise/SymmetricState.cs
+++ b/Noise/SymmetricState.cs
@@ -99,9 +99,7 @@ namespace Noise
                 Debug.Assert(length == 0 || length == Aead.KeySize || length == dh.DhLen);
 
                 Span<byte> output = stackalloc byte[3 * hash.HashLen];
-                
-				var ikx = new Span<byte>(inputKeyMaterial.ptr, length);
-                hkdf.ExtractAndExpand3(ck, hash.HashLen, ikx, output);
+                hkdf.ExtractAndExpand3(ck, hash.HashLen, inputKeyMaterial.ptr, length, output);
 
                 var slice = output.Slice(0, hash.HashLen);
                 for (var i = 0; i < hash.HashLen; i++)

--- a/Noise/SymmetricState.cs
+++ b/Noise/SymmetricState.cs
@@ -96,16 +96,19 @@ namespace Noise
 		/// If HashLen is 64, then truncates tempK to 32 bytes.
 		/// Calls InitializeKey(tempK).
 		/// </summary>
-		public void MixKeyAndHash(ReadOnlySpan<byte> inputKeyMaterial)
+		public void MixKeyAndHash(PskRef inputKeyMaterial)
 		{
             unsafe
             {
-                int length = inputKeyMaterial.Length;
+                int length = inputKeyMaterial.len;
                 Debug.Assert(length == 0 || length == Aead.KeySize || length == dh.DhLen);
 
                 Span<byte> output = stackalloc byte[3 * hash.HashLen];
-                var ckx = new Span<byte>(ck, hash.HashLen);
-                hkdf.ExtractAndExpand3(ckx, inputKeyMaterial, output);
+                
+				var ckx = new Span<byte>(ck, hash.HashLen);
+
+                var ikx = new Span<byte>(inputKeyMaterial.ptr, length);
+                hkdf.ExtractAndExpand3(ckx, ikx, output);
 
                 var slice = output.Slice(0, hash.HashLen);
                 for (var i = 0; i < hash.HashLen; i++)

--- a/Noise/Utilities.cs
+++ b/Noise/Utilities.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 
 namespace Noise
 {
@@ -10,8 +7,6 @@ namespace Noise
 	/// </summary>
 	internal static class Utilities
 	{
-		private static readonly RandomNumberGenerator random = RandomNumberGenerator.Create();
-
 		/// <summary>
 		/// Alignes the pointer up to the nearest alignment boundary.
 		/// </summary>
@@ -19,27 +14,6 @@ namespace Noise
 		{
 			ulong mask = (ulong)alignment - 1;
 			return (IntPtr)(((ulong)ptr + mask) & ~mask);
-		}
-
-		/// <summary>
-		/// Generates a cryptographically strong pseudorandom sequence of n bytes.
-		/// </summary>
-		public static byte[] GetRandomBytes(int n)
-		{
-			Debug.Assert(n > 0);
-
-			var bytes = new byte[n];
-			random.GetBytes(bytes);
-
-			return bytes;
-		}
-
-		// NoOptimize to prevent the optimizer from deciding this call is unnecessary.
-		// NoInlining to prevent the inliner from forgetting that the method was NoOptimize.
-		[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-		public static void ZeroMemory(Span<byte> buffer)
-		{
-			buffer.Clear();
 		}
 	}
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 before_build:
 - cmd: nuget restore
 build:


### PR DESCRIPTION
Our project does not expose the private key or any pre-shared keys to .NET process memory, and as such uses `sodium_malloc` to store that data in guarded heaps. 

This pull request updates the libraries to `netstandard2.0` / `netcoreapp3.1`, updates dependency packages, and refactors to use pointers to private keys.

It may be too aggressive for you, considering the use of `unsafe`, but it was what was needed to allow end-to-end storage of keys in guarded heaps.